### PR TITLE
FIXES #26

### DIFF
--- a/doc/base/getting-started.rst
+++ b/doc/base/getting-started.rst
@@ -116,10 +116,12 @@ then create the user, the database and the tables.
 
       sudo@host:~$ sudo su
       root@host:~$ sudo -i -u postgres
+      postgres@host:~$ psql
 
          postgres=# create database seiscomp;
          postgres=# create user sysop with encrypted password 'sysop';
          postgres=# grant all privileges on database seiscomp to sysop;
+         postgres=# alter database seiscomp owner to sysop;
          postgres=# exit
 
       root@host:~$ exit


### PR DESCRIPTION
In newer versions (at least >=13) of postgreSQL, some of the commands that are run to initiate the seiscomp database need to be run as the database owner. Granting all privileges is not enough.